### PR TITLE
Terraform設計ガイドライン: HCP Terraform に名称修正

### DIFF
--- a/documents/forTerraform/terraform_guidelines.md
+++ b/documents/forTerraform/terraform_guidelines.md
@@ -36,7 +36,7 @@ Terraformはインフラを宣言的にコード管理するツールである�
 対象とする技術は以下を想定している。
 
 - Terraform 1.10+
-- OSS利用のみ（Terraform Cloud は利用しない）
+- OSS利用のみ（HCP Terraformは利用しない）
 - AWS、Google Cloud、Azureなどのクラウドサービスに対しての利用
 
 また、利用者は以下の技術を理解しているとし、本ガイドラインではこれらについて解説はしない。


### PR DESCRIPTION
2024年4月に Terraform Cloud は HCP Terraform に名称が変更されました．
https://www.hashicorp.com/ja/blog/introducing-the-infrastructure-cloud

欧文・和文間の半角空白の有無に表記ゆれが見られましたが，ここでは周囲に合わせて半角空白なしとしています．


---
とても学びのあるガイドラインなのでよく参考にさせていただいています 🙇 