### PR TITLE
update devcontainer with editor settings and external host access

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f",
+      "integrity": "sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,45 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
 {
-  "name": "Node.js & TypeScript",
+  "name": "Arch Guidelines Workspace",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:4-22-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/base:trixie",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
-  // "features": {},
+  "features": {
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "24.15.0",
+      "npmVersion": "11.14.1"
+    }
+  },
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
 
+  "mounts": [
+    "source=${localWorkspaceFolderBasename}-node-modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
+  ],
+
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "npm install",
+  "postCreateCommand": "sudo chown vscode:vscode node_modules && npm install",
 
   // Configure tool-specific properties.
   "customizations": {
     "vscode": {
-      "extensions": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint"]
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "hediet.vscode-drawio.theme": "kennedy",
+        "hediet.vscode-drawio.offline": false
+      },
+      "extensions": [
+        "EditorConfig.EditorConfig",
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "DavidAnson.vscode-markdownlint",
+        "3w36zj6.textlint",
+        "hediet.vscode-drawio"
+      ]
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Future Enterprise Arch Guidelines",
   "main": "index.js",
   "scripts": {
-    "watch": "vitepress dev . --open",
+    "watch": "vitepress dev . --open --host 0.0.0.0",
     "build": "vitepress build .",
     "lint": "npm run lint:format && npm run lint:js",
     "lint:js": "eslint . .vitepress",


### PR DESCRIPTION
## 概要

開発体験向上のため devcontainer 設定を更新。ベースイメージの変更、開発に必要なVSCode拡張・設定の追加、ホストからのアクセス対応を行いました。

## 変更内容

### devcontainer のベース変更

- **イメージ**: `typescript-node:4-22-bookworm` → `base:trixie`
- **Node.js**: devcontainer features で `node:2` を導入し、バージョンを `24.15.0` / npm `11.14.1` に統一
- **node_modules を Docker volume にマウント**: ホストFSとの相互作用によるパフォーマンス低下や権限問題を回避
- **`postCreateCommand`**: volume mount に伴うパーミッション補正 (`sudo chown vscode:vscode node_modules`) を追加

### VSCode 拡張・設定の追加

導入した拡張:
- `EditorConfig.EditorConfig`
- `DavidAnson.vscode-markdownlint`
- `3w36zj6.textlint`
- `hediet.vscode-drawio`

設定:
- `editor.formatOnSave: true` でファイル保存時に自動フォーマット
- `editor.defaultFormatter`: `esbenp.prettier-vscode`
- `hediet.vscode-drawio` の theme / offline オプション

### `package.json` の `watch` スクリプト

- `vitepress dev . --open` → `vitepress dev . --open --host 0.0.0.0`
- devcontainer 外部（ホストOSのブラウザ）からアクセスできるよう `--host 0.0.0.0` を追加

### devcontainer-lock.json の追加

- devcontainer features の `node:2` を SHA256 で固定化

## 動作確認観点

- devcontainer リビルド後に `npm install` が正しく走り、`node_modules` volume にインストールされる
- `npm run watch` で立ち上げた VitePress dev server にホストOSのブラウザからアクセス可能
- VSCode 起動時に追加した拡張が自動でインストール・有効化される
