### PR TITLE
性能検証ツール選定フローのmermaid図の改行を修正

### DIFF
--- a/documents/forPerformanceTest/appendix.md
+++ b/documents/forPerformanceTest/appendix.md
@@ -86,9 +86,9 @@ config:
     rankSpacing: 200
 ---
 flowchart LR
-    Q1{"ラッシュテストの実施が必要か？"}
-    Q1 -- No --> Q2{"Lighthouseで解消しないエッジケースが存在するか？"}
-    Q1 -- Yes --> Q3{"Playwrightの資産を活用できそうか？"}
+    Q1{"ラッシュテストの<br>実施が必要か？"}
+    Q1 -- No --> Q2{"Lighthouseで解消しない<br>エッジケースが<br>存在するか？"}
+    Q1 -- Yes --> Q3{"Playwrightの資産を<br>活用できそうか？"}
     Q2 -- No --> Lighthouse["<p style='width:180px'>Lighthouseを採用</p>"]
     Q2 -- Yes --> WPT["<p style='width:180px'>WebPageTestを採用</p>"]
     Q3 -- No --> K6["<p style='width:180px'>k6-browserを採用</p>"]


### PR DESCRIPTION
## 概要

Appendix「性能検証ツール」の選定フロー図で、判断ノードのテキストが途切れていたため `<br>` で改行を追加した。

## 原因

結果ノード（Lighthouseを採用 など）には `<p style='width:180px'>` で幅指定があるのに対し、判断ノードには指定がなく、長い日本語テキストが1行に伸びていた。

```diff
-    Q1{"ラッシュテストの実施が必要か？"}
-    Q1 -- No --> Q2{"Lighthouseで解消しないエッジケースが存在するか？"}
-    Q1 -- Yes --> Q3{"Playwrightの資産を活用できそうか？"}
+    Q1{"ラッシュテストの<br>実施が必要か？"}
+    Q1 -- No --> Q2{"Lighthouseで解消しない<br>エッジケースが<br>存在するか？"}
+    Q1 -- Yes --> Q3{"Playwrightの資産を<br>活用できそうか？"}
```

## 横断チェックの結果

リポジトリ内の全mermaid図（6文書）のノードラベルを機械的に走査し、`<br>` / `\n` による改行を考慮したうえで「1行が日本語14文字以上」のものを抽出した。

**該当5件はいずれも既に改行済みで、対処不要と判断した**（同じ図の中で他ノードと同程度の長さに収まっており、突出していない）。

| 文書 | ラベル | 判断 |
| :-- | :-- | :-- |
| forDataGovernance | `CI/CDパイプライン<br/>(メタデータ抽出・ドキュメント生成)` | 改行済み。同図の他ノードも同程度 |
| forDataManagement | `ステップ3: 旧テーブル/ビューの完全削除` | 同図が全体的に長文ノードで構成され統一されている |
| forIF | `受信側システム<br/>スキーマ検証・受信ワークへ書き込み` | 改行済み。隣接ノードも同程度の長さ |
| forMail | `対象アドレスの<br>ソフトバウンス回数をカウント` | 改行済み。同図で最長だが2文字差 |
| forPrinciple | `1つのDDL変更だけで、<br/>関連テーブルは参照により恩恵を受ける` | 改行済み。対になる図と並列 |

## 補足: 改行記法の混在（対処せず）

`<br>` `<br/>` `\n` の3種類が混在している。いずれもmermaidで動作するため表示上の問題はないが、統一するなら別途対応したい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)