### PR TITLE
ログ設計ガイドライン: 他文書から参照されている見出しのアンカー切れを修正

### DIFF
--- a/documents/forLog/log_guidelines.md
+++ b/documents/forLog/log_guidelines.md
@@ -599,7 +599,7 @@ Web API設計ガイドライン > [機能配置](/documents/forWebAPI/web_api_gu
 | 処理時間         | http.server.request.duration | ー     | ✅️     | ミリ秒を推奨                                                                                                         |
 | User Agent       | user_agent.original          | ✅️     | ✅️     | クライアントの特定に利用する。                                                                                       |
 
-## バッチ実行時のログ出力
+## バッチ実行時のログ出力 {#バッチ実行時のログ出力}
 
 バッチ処理でも適切なログを出力することで、何か課題が生じた際に解析の手がかりとなり、保守運用時コストを低減できる。
 


### PR DESCRIPTION
バッチ設計ガイドラインから参照されているリンクが機能していなかったため、参照先の見出しに明示アンカーを付与した。**1行の修正のみ。**

## 背景

`documents/forBatch/batch_guidelines.md` に以下の参照がある。

> ログ設計ガイドライン > [バッチ実行時のログ出力](/documents/forLog/log_guidelines.html#バッチ実行時のログ出力) 参照。

VitePressが生成する見出しIDは濁点・半濁点が分解された形（NFD）になるため、合成済み（NFC）で書かれたこのリンクはページ遷移はするものの、アンカー位置には飛ばない状態だった。

## 変更内容

```diff
-## バッチ実行時のログ出力
+## バッチ実行時のログ出力 {#バッチ実行時のログ出力}
```

参照元（バッチ設計ガイドライン）を書き換えずに済むよう、ASCIIではなく元の日本語のままアンカーを明示した。この見出しはログ設計ガイドライン内からはリンクされていないため、markdownlintの警告も増えない。

ロット10のレビュー（#367）中に見つけた不具合だが、修正対象が別文書のため独立したPRとしている。

## 検証

- ビルド後のHTMLで `id="バッチ実行時のログ出力"` が生成されることを確認
- ログ設計ガイドライン内の他のページ内リンクに切れがないことも併せて確認（切れなし）
- textlint: エラー0 / prettier: 整形済み / VitePressビルド: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)