### PR TITLE
はじめての非機能要件をトップページとナビゲーションに追加 (#394)

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -419,6 +419,10 @@ export default defineConfig({
                 text: "はじめての性能テスト",
                 link: "/documents/forPerformanceTest/performance_test.html",
               },
+              {
+                text: "はじめての非機能要件",
+                link: "/documents/forNFR/",
+              },
             ],
           },
           {

--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -416,12 +416,12 @@ export default defineConfig({
             text: "はじめての〇〇シリーズ",
             items: [
               {
-                text: "はじめての性能テスト",
-                link: "/documents/forPerformanceTest/performance_test.html",
-              },
-              {
                 text: "はじめての非機能要件",
                 link: "/documents/forNFR/",
+              },
+              {
+                text: "はじめての性能テスト",
+                link: "/documents/forPerformanceTest/performance_test.html",
               },
             ],
           },

--- a/index.md
+++ b/index.md
@@ -48,6 +48,9 @@ hero:
       text: 性能テスト
       link: ./documents/forPerformanceTest/
     - theme: alt
+      text: 非機能要件
+      link: ./documents/forNFR/
+    - theme: alt
       text: Gitブランチフロー
       link: ./documents/forGitBranch/
     - theme: alt

--- a/index.md
+++ b/index.md
@@ -45,11 +45,11 @@ hero:
       text: ログ
       link: ./documents/forLog/
     - theme: alt
-      text: 性能テスト
-      link: ./documents/forPerformanceTest/
-    - theme: alt
       text: 非機能要件
       link: ./documents/forNFR/
+    - theme: alt
+      text: 性能テスト
+      link: ./documents/forPerformanceTest/
     - theme: alt
       text: Gitブランチフロー
       link: ./documents/forGitBranch/


### PR DESCRIPTION
Fixes #394

## 変更内容

「はじめての非機能要件」への入口が、サイドバー（`/documents/forNFR/` 配下）にしか存在しなかったため、トップページとハンバーガーメニューから参照できるようにした。

| 場所 | 変更 |
| :--- | :--- |
| `index.md` | ヒーローのボタンに「非機能要件」を追加（`theme: alt`） |
| `.vitepress/config.mjs` | ナビの `Guidelines` > `はじめての〇〇シリーズ` に「はじめての非機能要件」を追加 |

サイドバーは既に登録済みのため変更なし。

## 補足

- リンク先は `/documents/forNFR/` とした。性能テストはガイドライン本体へ直リンクしているが、非機能要件は第一部・第二部・Appendix の3部構成なので、入口となるランディングページを指す方が読者が選びやすい
- 並び順は「はじめての非機能要件」→「はじめての性能テスト」とした。要件定義→テストという時系列に沿う

## 確認したこと

- `npm run lint` / `npm run build` が成功する
- ビルド後のHTMLで、トップページのボタンと各ページのナビに上記の順序でリンクが出力される
- リンク先 4ページ（`forNFR/`, `overview.html`, `knowledge.html`, `appendix.html`）がいずれも200応答

🤖 Generated with [Claude Code](https://claude.com/claude-code)