### PR TITLE
注記の色を技術ブログの note にそろえる

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -227,3 +227,29 @@ h6 {
   margin-left: 0;
   margin-right: 4px;
 }
+
+/* 注記の地の色を技術ブログの note にそろえる (#409)。名前は engine の語彙で交差するので
+   意味で対応させる: tip（本サイトでは「推奨」）→ ブログの info（緑）、info（補足）→
+   ブログの tip（灰青）、warning → warn、danger → alert。
+   中のコードの地は、地より一段濃い同じ色（ブログの code-bg と同じ HSL 0.94） */
+:root {
+  --vp-custom-block-tip-bg: #e5f8e2;
+  --vp-custom-block-tip-code-bg: #d1f1cc;
+  --vp-custom-block-info-bg: #eff0f3;
+  --vp-custom-block-info-code-bg: #dfe1e6;
+  --vp-custom-block-warning-bg: #fdf9e2;
+  --vp-custom-block-warning-code-bg: #faf2c9;
+  --vp-custom-block-danger-bg: #ffdbdb;
+  --vp-custom-block-danger-code-bg: #fdc0c0;
+}
+
+.dark {
+  --vp-custom-block-tip-bg: #243720;
+  --vp-custom-block-tip-code-bg: #3f6038;
+  --vp-custom-block-info-bg: #313237;
+  --vp-custom-block-info-code-bg: #565860;
+  --vp-custom-block-warning-bg: #363320;
+  --vp-custom-block-warning-code-bg: #5e5938;
+  --vp-custom-block-danger-bg: #482a2a;
+  --vp-custom-block-danger-code-bg: #7e4a4a;
+}


### PR DESCRIPTION
Fixes #409

`::: tip` `::: info` `::: warning` `::: danger` の地の色を、技術ブログの note の4色にそろえる。

| VitePress | 本サイトでの意味 | ブログの note | 明 | 暗 |
| --- | --- | --- | --- | --- |
| `tip` | 推奨（322件） | info（緑） | `#e5f8e2` | `#243720` |
| `info` | 補足（269件） | tip（灰青） | `#eff0f3` | `#313237` |
| `warning` | 注意（97件） | warn（黄） | `#fdf9e2` | `#363320` |
| `danger` | 危険（0件） | alert（赤） | `#ffdbdb` | `#482a2a` |

名前は engine の語彙で交差するので**意味で対応させた**。中のインラインコードの地は、地より一段濃い同じ色（ブログの `code-bg()` と同じ HSL 0.94。暗はブログの `dark-note-*-code` の値）。VitePress が公開している `--vp-custom-block-*-bg` / `-code-bg` の上書きだけで、枠・文字色・余白は既定のまま（本文の文字は4色の上で AA を大きく上回る。ブログの実測 7.85〜9.49）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)