### PR TITLE
インラインコードの文字色を本文と同じにする

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -5,6 +5,20 @@
   border-top: 1px solid var(--vp-c-divider);
 }
 
+/* インラインコードの文字は本文の色 (#419)。技術ブログと同じ。コードは地で区別されて
+   いるので、文字まで青にすると注記の色の上で読みにくく、リンクとも見分けが付かない。
+   注記の中は VitePress が種類ごとに brand-1 を当て直しているので、そちらも戻す。
+   リンクの中のコードだけはリンクの色のまま */
+:root {
+  --vp-code-color: var(--vp-c-text-1);
+}
+.vp-doc .custom-block code {
+  color: var(--vp-c-text-1);
+}
+.vp-doc .custom-block a > code {
+  color: var(--vp-code-link-color);
+}
+
 :root {
   --vp-home-hero-name-color: transparent;
   --vp-home-hero-name-background: -webkit-linear-gradient(


### PR DESCRIPTION
Fixes #419

VitePress 既定はインラインコードの文字がブランド色（`--vp-code-color`）で、`::: tip` などの注記の中でも種類ごとに `brand-1` が当て直されている。地の色の上で青い文字は読みにくく、リンクとも見分けが付かない。

技術ブログと同じく**本文の色**（`--vp-c-text-1`）にする。コードは地（#414 なら注記の地より一段濃い同じ色）で区別されているので、文字まで変える必要が無い。**リンクの中のコードだけはリンクの色のまま**（`--vp-code-link-color`）。

- `:root { --vp-code-color: var(--vp-c-text-1) }`（本文中）
- `.vp-doc .custom-block code { color: var(--vp-c-text-1) }`（注記の中。VitePress の種類別の指定より後勝ち）
- `.vp-doc .custom-block a > code { color: var(--vp-code-link-color) }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)