### PR TITLE
表のセルの罫線を技術ブログと同じ濃さにする（注記の中は一段濃く）

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -291,6 +291,23 @@ h6 {
 .vp-doc tr:nth-child(2n) {
   background-color: var(--vp-c-bg);
 }
+/* セルの罫線は技術ブログと同じ濃さにする (#421)。VitePress 既定の
+   --vp-c-divider は区切りのための段で、白地で 1.29・注記の地の上では
+   1.01〜1.22 しか出ない（danger の中では消える）。行を目で追う役を
+   この線が担っているので、枠より一段強い段を当てる。
+   注記の中でも同じ線を使う（地の色に染めると表ごとに濃さが変わり、
+   構造の読み取りが不安定になる） */
+:root {
+  --table-border: #ccc;
+}
+.dark {
+  --table-border: #4d4d59;
+}
+.vp-doc tr,
+.vp-doc th,
+.vp-doc td {
+  border-color: var(--table-border);
+}
 .vp-doc th {
   background-color: var(--vp-c-bg-soft);
 }

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -308,6 +308,21 @@ h6 {
 .vp-doc td {
   border-color: var(--table-border);
 }
+/* 注記の中は地が白より暗いので、白地に合わせた1本を持ち込むと一段弱くなる
+   （白地 1.61 に対して tip 1.44 / info 1.41 / warning 1.52）。無彩色のまま
+   濃さだけ一段振って、白地の表と同じ見え方に戻す。リンクの色を地ごとに
+   暗い側へ振るのと同じ考え方で、色相は増やさない */
+:root {
+  --table-border-on-note: #bfbfbf;
+}
+.dark {
+  --table-border-on-note: #5f5f6d;
+}
+.vp-doc .custom-block tr,
+.vp-doc .custom-block th,
+.vp-doc .custom-block td {
+  border-color: var(--table-border-on-note);
+}
 .vp-doc th {
   background-color: var(--vp-c-bg-soft);
 }

--- a/serve/arch-guidelines
+++ b/serve/arch-guidelines
@@ -1,1 +1,0 @@
-/tmp/claude-1000/-home-ubuntu-future-architect-github-io/0089dd44-7fdb-4d52-ba08-6ec9b0a82008/scratchpad/wt421/docs

--- a/serve/arch-guidelines
+++ b/serve/arch-guidelines
@@ -1,0 +1,1 @@
+/tmp/claude-1000/-home-ubuntu-future-architect-github-io/0089dd44-7fdb-4d52-ba08-6ec9b0a82008/scratchpad/wt421/docs


### PR DESCRIPTION
Fixes #421

## 変更内容

表のセルの罫線を2段持つ。

- `--table-border`（明るい側 `#ccc` / ダーク `#4d4d59`）… 本文の表。技術ブログの `rule-strong` と同じ値。VitePress 既定の `--vp-c-divider` は区切りのための段で、罫線としては一段薄い
- `--table-border-on-note`（`#bfbfbf` / `#5f5f6d`）… 注記（`::: tip` など）の中の表

## 判断した点

- **注記の中は一段濃くする。** 注記の地は白より暗いので、白地に合わせた1本をそのまま持ち込むと必ず一段弱くなる（白地 1.61 に対して tip 1.44 / info 1.41 / warning 1.52）。無彩色のまま濃さだけ振って、白地の表と同じ見え方に戻す。**リンクの色を地ごとに暗い側へ振る**（`link-on-note`）のと同じ考え方
  - 技術ブログの「罫線は地の色に染めない」は**色相**の話（表ごとに濃さが変わって構造の読み取りが不安定になる、という理由）なので、無彩色のまま濃さを1段持つのは抵触しない。注記の色ごとに値を分けることはしていない（4色まとめて1つの値）
  - 一段強い `#b4b4b4`（tip 1.86 / info 1.82 / warning 1.96）と並べて実物を見比べ、「注記の中だけ弱い」が消えて強すぎない `#bfbfbf` を採った
- **`tr` の `border-top` も同じ値にする。** `border-collapse: collapse` ではセルの罫線が行の罫線に勝つため表示は変わらないが、同じ1本の線に2つの値が残っていると次に触るときに読めない

地とのコントラスト比（実測）:

| 地 | 変更前 `#e2e2e3` | 変更後 |
| --- | --- | --- |
| 白（本文の表） | 1.29 | 1.61 |
| tip | 1.16 | 1.65 |
| info | 1.14 | 1.61 |
| warning | 1.22 | 1.74 |
| danger | 1.01 | 1.44 |

ダークは本文の地で 1.27 → 2.06、注記の中で 1.06 → 2.04。注記の中の表は30個（tip 26 / info 3 / warning 1 / danger 0）。

## 確認したこと

- `npm run build` の生成 CSS で、`.vp-doc tr,.vp-doc th,.vp-doc td{border-color:var(--table-border)}` が VitePress 既定より後ろに出ている（詳細度が同じなので順序で決まる）。注記の側は `.vp-doc .custom-block tr,…`（0,2,1）で本文の側（0,1,1）に勝つ
- `npm run lint`
