### PR TITLE
共有ボタンを訪問済みでも同じ色にする

### DIFF
--- a/.vitepress/theme/components/PageTitle.vue
+++ b/.vitepress/theme/components/PageTitle.vue
@@ -169,7 +169,11 @@ function copyLink() {
   margin: 0;
   position: relative;
 }
-.share-btn {
+/* 訪問済みでも色を変えない (#422)。本文の参照リンクの紫（#407）は
+   .vp-doc の中にある共有ボタンにも当たるが、ここでの色は行き先の合図で、
+   読んだ記録ではない。詳細度で勝つように :visited を並べて書く */
+.share-btn,
+.share-btn:visited {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -190,18 +194,23 @@ function copyLink() {
     color 0.05s ease;
 }
 .share-btn:hover,
-.share-btn:focus-visible {
+.share-btn:visited:hover,
+.share-btn:focus-visible,
+.share-btn:visited:focus-visible {
   background: var(--vp-c-brand-3);
   border-color: var(--vp-c-brand-3);
   color: #fff;
   text-decoration: none;
 }
 /* ダークではネイビーが地に沈むので、明るい青で置く */
-.dark .share-btn {
+.dark .share-btn,
+.dark .share-btn:visited {
   color: var(--vp-c-brand-1);
 }
 .dark .share-btn:hover,
-.dark .share-btn:focus-visible {
+.dark .share-btn:visited:hover,
+.dark .share-btn:focus-visible,
+.dark .share-btn:visited:focus-visible {
   background: var(--vp-c-brand-1);
   border-color: var(--vp-c-brand-1);
   color: var(--vp-c-bg);


### PR DESCRIPTION
Fixes #422

## 変更内容

共有ボタン（X / Facebook / はてなブックマーク）のアイコンが、一度押すと訪問済みの紫（`#590fc7`）になっていた。`:visited` でも同じ色を保つようにする。

`#407` の `.vp-doc a:visited` は本文の参照リンクに「読んだかどうか」を返すためのもので、`<page-title/>` が本文の先頭に置かれる関係で共有ボタンにも当たっていた。ここでの色は行き先の合図であって読んだ記録ではないので、押した後も動かさない。

## 判断した点

- **打ち消しは共有ボタン側に置く。** `.vp-doc a:visited` の側を `:not()` で絞ると、本文の決まりが特定の部品を名指しすることになる。色は `#417` で共有ボタンが自分で持っているので、状態も同じ場所で持つ
- **`:visited` を並べて書いて詳細度で勝たせる。** scoped スタイルは `.share-btn[data-v-xxx]:visited`（0,3,0）になり、`.vp-doc a:visited`（0,2,0）に読み込み順によらず勝つ。`.share-btn` 単体（0,2,0）では同点で、順序が変わると負ける
- hover / focus-visible も同じ理由で `:visited` 付きを並べる（`.vp-doc a:visited:hover` が 0,3,0 なので、こちらは 0,4,0 で勝つ）

## 確認したこと

- `npm run build` の生成 CSS に `.dark .share-btn[data-v-74a9273a],.dark .share-btn[data-v-74a9273a]:visited{color:var(--vp-c-brand-1)}` のように `:visited` 付きのセレクタが出ている
- `npm run lint`
