### PR TITLE
注記の中のリンクを種別ごとの色相にする

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -155,16 +155,18 @@
 }
 
 /* 訪問済みは紫 (#407)。技術ブログの link-visited と同じ値で、白地・コードの地の
-   両方で AA を満たす。hover でも色は動かさない（下線の太さで返す） */
+   両方で AA を満たす。hover でも色は動かさない（下線の太さで返す）。
+   注記の中でも同じ値を使うのでトークンにしている (#427) */
+:root {
+  --link-visited: #590fc7;
+}
+.dark {
+  --link-visited: #c8a8ff;
+}
 .vp-doc a:visited,
 .vp-doc a:visited:hover,
 .vp-doc a:visited > code {
-  color: #590fc7;
-}
-.dark .vp-doc a:visited,
-.dark .vp-doc a:visited:hover,
-.dark .vp-doc a:visited > code {
-  color: #c8a8ff;
+  color: var(--link-visited);
 }
 
 /* ヒーロー画像を透過させる */
@@ -390,4 +392,53 @@ h6 {
   --vp-custom-block-warning-code-bg: #5e5938;
   --vp-custom-block-danger-bg: #482a2a;
   --vp-custom-block-danger-code-bg: #7e4a4a;
+}
+
+/* 注記の中のリンクは、その注記の地の色相を借りる (#427)。技術ブログ (#3241) と同じ。
+   色を持つ箱の中で青いリンクは唯一の外来色になる。色相まで振れるのは #404 で
+   本文のリンクが常時下線を持つようになったからで、リンクであることは下線が名乗り、
+   色は「その注記のものである」ことだけを担う。
+
+   値は「地の色相を保ち、注記の地とその中のインラインコードの地の両方で 4.6 を
+   満たす、いちばん明るい色」。AA の 4.5 ちょうどでは取らない。
+   対応させるのは名前ではなく地の色で、本サイトの tip（緑）はブログの info、
+   info（灰青）はブログの tip に当たる (#409)。
+   info の地は無彩色に近いので、色相を保つと青になる */
+:root {
+  --link-on-note-tip: #257718;
+  --link-on-note-info: #2d58d7;
+  --link-on-note-warning: #7b6d18;
+  --link-on-note-danger: #ac1b1b;
+}
+/* 暗い側は種別で割らず1色。暗い地ではリンクを明るくするしかなく、色相を保って
+   彩度を残すと注記の中のコードの地で 2.5 まで落ち、AA を取ると本文との比が
+   1.2 のほぼ白になる。種別ごとの色相は明るい側だけが持つ */
+.dark {
+  --link-on-note-tip: #8ec2ff;
+  --link-on-note-info: #8ec2ff;
+  --link-on-note-warning: #8ec2ff;
+  --link-on-note-danger: #8ec2ff;
+}
+.vp-doc .custom-block.tip a,
+.vp-doc .custom-block.tip a code {
+  color: var(--link-on-note-tip);
+}
+.vp-doc .custom-block.info a,
+.vp-doc .custom-block.info a code {
+  color: var(--link-on-note-info);
+}
+.vp-doc .custom-block.warning a,
+.vp-doc .custom-block.warning a code {
+  color: var(--link-on-note-warning);
+}
+.vp-doc .custom-block.danger a,
+.vp-doc .custom-block.danger a code {
+  color: var(--link-on-note-danger);
+}
+/* 訪問済みは種別で割らず紫のまま。紫はサイト全体で訪問済みの意味を持ち、
+   未訪問と色相で分かれる。種別ごとに割ると同じ色相の明度違いになって読めなくなる。
+   詳細度が上の未訪問と同じ (0,3,1) なので、後ろに置いて勝たせる */
+.vp-doc .custom-block a:visited,
+.vp-doc .custom-block a:visited code {
+  color: var(--link-visited);
 }


### PR DESCRIPTION
Fixes #427

## 変更内容

注記の中のリンクを、その注記の地の色相を借りた色にする。技術ブログの [#3241](https://github.com/future-architect/future-architect.github.io/pull/3243) と同じ。

| 種別（地） | 変更前 | 変更後 | 注記の地 / コードの地 |
| --- | --- | --- | --- |
| tip（緑） | `#0a58ca` | `#257718` | 5.05 / 4.60 |
| info（灰青） | `#0a58ca` | `#2d58d7` | 5.28 / 4.60 |
| warning（黄） | `#915930` | `#7b6d18` | 4.90 / 4.60 |
| danger（赤） | `#b8272c` | `#ac1b1b` | 5.61 / 4.60 |

ダークは4種とも `#8ec2ff` の1色（変更前は tip / info が `#7cb8ff`、warning `#f9b44e`、danger `#f66f81`）。訪問済みは紫のまま。

## 判断した点

- **色相を振れるのは `#404` で本文のリンクが常時下線を持つようになったから。** リンクであることは下線が名乗り、色は「その注記のものである」ことだけを担う
- **値は「地の色相を保ち、注記の地とその中のインラインコードの地の両方で 4.6 を満たす、いちばん明るい色」。** AA の 4.5 ちょうどでは取らない。技術ブログが算出した値をそのまま使える（注記の地とコードの地が `#409` で同じ値にそろっているため）
- **対応させるのは名前ではなく地の色。** 本サイトの `tip`（緑）はブログの `info`、`info`（灰青）はブログの `tip` に当たる（`#409` と同じ読み替え）。info の地は無彩色に近いので、色相を保つと青になる
- **暗い側は種別で割らず1色。** 暗い地ではリンクを明るくするしかなく、色相を保って彩度を残すと注記の中のコードの地で 2.5 まで落ちる。AA を取ろうとすると本文との比が 1.2 のほぼ白になる（コードの地は本文の文字でも 5.3 しか出ない明るさなので、ここは地の側の制約）
- **訪問済みは種別で割らず紫のまま。** 紫はサイト全体で訪問済みの意味を持ち、未訪問と色相で分かれる。種別ごとに割ると同じ色相の明度違いになって読めなくなる。現在の `#590fc7` は注記の8つの地すべてで 5.81 以上あるので、注記用の値は作らない（`#407` の値を `--link-visited` としてトークンにし、本文と注記が同じ値を引く形にした）
- **hover では色を動かさない。** 本文の決め（`#404`。下線の太さで返す）にそろえる。VitePress 既定は `--vp-c-*-2` へ動かしていて、danger は hover で 3.66 / 3.01、暗い側の warning は 4.65 / 2.60 まで落ちていた
- **`::: details` などブログに無い種別は触らない**（本サイトでは0件。地が無彩色のグレーなので既定の青のままでよい）

## 直った AA 違反

- 明るい側 danger のリンク: コードの地で 4.01（hover 3.01）
- 暗い側 danger のリンク: 地で 4.58・コードの地で 2.53（hover 3.44 / 1.90）
- 暗い側 warning の hover: 4.65 / 2.60

## 確認したこと

- `npm run build` の生成 CSS を機械で解いて、注記の中のリンクとその中のコードについて 静止 / hover / 訪問済み / 訪問済み+hover の4状態を照合（詳細度と出現順の両方を計算）。8通りすべてが意図した規則に決まる
  - `a` 静止・hover → `--link-on-note-tip`（`.vp-doc .custom-block.tip a`）
  - `a` 訪問済み・訪問済み+hover → `--link-visited`（`.vp-doc .custom-block a:visited`）
  - `a code` も同じ4状態で同じ結果（`.vp-doc .custom-block a > code` の `--vp-code-link-color` に勝つ）
- 対象は注記の中のリンク463本・26ページ（tip 105 / info 352 / warning 6 / danger 0）
- `npm run lint`
