### PR TITLE
テキスト選択の帯をブランドのネイビーにする

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -169,6 +169,30 @@
   color: var(--link-visited);
 }
 
+/* テキスト選択の帯をブランドのネイビーに（技術ブログ #3103）。--vp-c-brand-3 は
+   #403 のブランドのネイビー。::-moz-selection は単独のルールにする。セレクタ
+   リストに 1 つでも解釈できないセレクタが混ざると、Chrome / Safari はルール
+   ごと捨てる（技術ブログ #3058） */
+::-moz-selection {
+  color: #fff;
+  background: var(--vp-c-brand-3);
+}
+::selection {
+  color: #fff;
+  background: var(--vp-c-brand-3);
+}
+/* ネイビーのまま暗い地に置くと帯とページの地の差が 1.05 で見えなくなるため、
+   向きを逆にする。#c2c7eb は技術ブログの dark-selection と同じ値
+   （brand-navy と同じ色相 233° のまま彩度を半分に落とした帯） */
+.dark ::-moz-selection {
+  color: var(--vp-c-bg);
+  background: #c2c7eb;
+}
+.dark ::selection {
+  color: var(--vp-c-bg);
+  background: #c2c7eb;
+}
+
 /* ヒーロー画像を透過させる */
 .image-src {
   opacity: 0.1;


### PR DESCRIPTION
Fixes #432

## 変更内容

`.vitepress/theme/style.css` にテキスト選択の帯（`::selection`）を追加した。技術ブログ（future-architect.github.io、#3103）と同じ形で、明るい側はブランドのネイビーの帯に白文字、暗い側は向きを逆にしてネイビーを薄くした帯（`#c2c7eb`）に地の色の文字にする。

配置は本文リンクの色を決めている塊（`--link-visited` の直後）。`::-moz-selection` と `::selection` は別々のルールに分けている（セレクタリストに 1 つでも解釈できないセレクタが混ざると、Chrome / Safari はルールごと捨てるため。技術ブログ #3058）。

## 判断した点

- 明るい側の背景は `#0a1561` のリテラルではなく `var(--vp-c-brand-3)` を参照した。本サイトでは #403 でこの値をブランドのネイビーとして既に `--vp-c-brand-3` に置いているため（フォーカスリング候補 #431-6 も同じトークンを引く想定）
- 暗い側の文字色は `var(--vp-c-bg)`（`#1b1b1f`）を参照した。帯の背景 `#c2c7eb` はブログの `dark-selection` と同じ値で、本サイトに対応するトークンが無いためリテラルで置いた

## コントラスト比（相対輝度から自分で計算、WCAG AA = 4.5）

- 白文字 `#fff` と `--vp-c-brand-3` `#0a1561`: **16.24**
- 暗い側の文字 `#1b1b1f` と帯 `#c2c7eb`: **10.35**（帯とページの地の差も同じ 10.35）
- 参考: ネイビーのまま暗い地に置くと `#0a1561` 対 `#1b1b1f` で **1.05**（帯が見えなくなる）
- 参考: 暗い側のコードブロックの地 `#161618` と帯 `#c2c7eb`: **10.90**

いずれも AA を満たす。

## 確認したこと

- `npm run lint`（prettier + eslint）が通ることを確認した
- `npm run build` を実行し、`docs/assets/*.css` を grep して4本のルールが**別々に**焼かれていることを確認した（`::-moz-selection` が `::selection` と同じルールに混ざっていない）

```
::-moz-selection{color:#fff;background:var(--vp-c-brand-3)}
::selection{color:#fff;background:var(--vp-c-brand-3)}
.dark ::-moz-selection{color:var(--vp-c-bg);background:#c2c7eb}
.dark ::selection{color:var(--vp-c-bg);background:#c2c7eb}
```
