### PR TITLE
フォーカスリングとスキップリンクを技術ブログと同じ形にする

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -327,6 +327,8 @@ export default defineConfig({
     outline: {
       level: "deep",
     },
+    // 既定は英語の "Skip to content"。サイトの他の UI と同じ日本語にする (#435)
+    skipToContentLabel: "本文へスキップ",
     nav: [
       {
         text: "Guidelines",

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -119,6 +119,47 @@
   transition-duration: 0.05s;
 }
 
+/* 所在の目印。反応（hover）とは別の役なので、色は差し色ではなく塗りのネイビー、
+   太さは 2px の1つだけ（技術ブログ #2686 / #2847）。VitePress 既定は a が UA の
+   リング、button が 4px の -webkit-focus-ring-color で部品ごとに違う。
+   暗い側はネイビーが地の上で 2.67 と非テキストの 3:1 に届かないので、
+   文字の最上段（12.81）に替える。
+   広げているのは本文とスキップリンクだけ——ナビ・サイドバー・検索は
+   部品ごとに outline: none / 5px auto を持ち、器の縁で輪郭が切れるかは別に見る */
+.vp-doc a:focus-visible,
+.vp-doc button:focus-visible,
+.vp-doc summary:focus-visible,
+#app .VPSkipLink:focus-visible {
+  outline: 2px solid var(--vp-c-brand-3);
+  outline-offset: 2px;
+}
+.dark .vp-doc a:focus-visible,
+.dark .vp-doc button:focus-visible,
+.dark .vp-doc summary:focus-visible,
+.dark #app .VPSkipLink:focus-visible {
+  outline-color: var(--vp-c-text-1);
+}
+
+/* スキップリンクは画面に対して固定する（技術ブログ #2846）。VitePress 既定の
+   絶対配置だと、ページの途中で Tab を押したときにブラウザがこのリンクを
+   見せるためページ先頭までスクロールし、読んでいた位置を失う。
+   塗りはネイビーに白文字（16.24）で、影は持たない。
+   位置は VitePress のまま（縁から 8px なので outline-offset の輪郭が画面に収まる）。
+   .visually-hidden（position）と scoped style（色・影）に勝つよう #app を前置する。
+   :focus で clip を外す規則は scoped のまま効くので clip / width / height は触らない */
+#app .VPSkipLink {
+  position: fixed;
+  color: #fff;
+  background-color: var(--vp-c-brand-3);
+  box-shadow: none;
+}
+/* 暗い側はネイビーが地に沈むので、明るい青の板に地の色の文字（8.30）。
+   共有ボタンのダークと同じ向き */
+.dark #app .VPSkipLink {
+  color: var(--vp-c-bg);
+  background-color: var(--vp-c-brand-1);
+}
+
 /* 見出しのアンカーは、左の「#」ではなく見出し文の末尾にリンクのアイコン (#410)。
    技術ブログと同じ絵（Tabler の link）。左に出すと狭い画面で本文の左端より外に出るし、
    記号よりアイコンのほうが「このリンクをコピーできる」と読める。


### PR DESCRIPTION
Fixes #435

`#431` の候補 6（フォーカスリング）と候補 7（スキップリンク）。どちらも「キーボードの読者に対する『いまここ』の示し方」なので 1 本にまとめた。

## 変更内容

### フォーカスリング（`.vitepress/theme/style.css`）

`:focus-visible` に **2px のネイビー ＋ `outline-offset: 2px`** の 1 つだけを当てる（技術ブログ #2686 / #2847）。VitePress 既定は `a` が UA のリング（Chrome は `outline: auto` の青）、`button` が `4px auto -webkit-focus-ring-color` で、部品ごとに太さも色も違っていた。

暗い側はネイビー（`--vp-c-brand-3` = `#0a58ca`）が地の上で **2.67** と非テキストの 3:1 に届かないので、ブログにならって文字の最上段（`--vp-c-text-1`）に替える。

### スキップリンク（`.vitepress/theme/style.css` ＋ `.vitepress/config.mjs`）

`position: fixed` にする（技術ブログ #2846）。VitePress 既定は `.visually-hidden` の絶対配置で、**ページの途中を読んでいる読者が Tab を押すと、ブラウザがこのリンクを見せるためにページ先頭までスクロールする**。固定なら読んでいた位置のまま帯だけが出る。

見た目は塗りをネイビー、文字を白にして影を落とす。既定は地がページと同じ色（`--vp-c-bg`）で影だけが浮いている板だった。

文言は `themeConfig.skipToContentLabel: "本文へスキップ"` を足した。既定の `Skip to content` のままだと、サイトの他の UI がすべて日本語なのにここだけ英語で出る。CSS ではないが同じ話なのでこの PR に含めた。

## 計算したコントラスト比

相対輝度から自分で計算した（輪郭は非テキストなので 3:1、文字は AA = 4.5）。`#431` に書かれていた値（16.24 / 2.67 / 12.81 / 8.30）はいずれも再現した。

**輪郭**

| 輪郭の色 | 地 | 比 |
| --- | --- | --- |
| `--vp-c-brand-3` `#0a1561` | 白 `#ffffff` | **16.24** |
| 〃 | 注記の地でいちばん暗い danger `#ffdbdb` | 12.69 |
| 〃 | コードブロックの地 `#f6f6f7` | 15.04 |
| 暗: `--vp-c-brand-3` `#0a58ca` | `#1b1b1f` | **2.67**（3:1 に届かないので使わない） |
| 暗: `--vp-c-text-1` `#dfdfd6` | `#1b1b1f` | **12.81** |
| 〃 | 暗い側の注記の地（tip / info / warning / danger） | 9.49〜9.55 |
| 〃 | 暗い側の注記の中のコードの地でいちばん明るい danger `#7e4a4a` | 5.28 |

明るい側は輪郭がどの地の上でも 12.69 以上、暗い側は 5.28 以上で、いずれも 3:1 を満たす。

**スキップリンク**

| 文字 | 地 | 比 |
| --- | --- | --- |
| 白 `#ffffff` | ネイビー `#0a1561` | **16.24** |
| 暗: `--vp-c-bg` `#1b1b1f` | `--vp-c-brand-1` `#7cb8ff` | **8.30** |

どちらも AA を満たす。暗い側で明るい板に地の色の文字を置く形は、共有ボタンのダーク（`PageTitle.vue` の `.share-btn`）が既に採っている向き。

## 判断した点

### 輪郭の適用範囲は「本文（`.vp-doc`）とスキップリンク」だけ

ナビ・サイドバー・検索には広げなかった。

- 検索ボタンは `VPNavBarSearchButton.vue` が `outline: 5px auto -webkit-focus-ring-color`、検索の入力欄は `VPLocalSearchBox.vue` が `outline: none`、サイドバーの器は `VPSidebar.vue` が `outline: 0` を持つ。部品ごとに別の作りになっている
- ナビの帯とサイドバーは幅で見た目が変わり、`outline-offset: 2px` の輪郭が器の縁で切れるかどうかはブラウザで描かないと分からない
- 本文の中のリンク（箇条書き 6,249 行と表 1,011 に散っている）が読者の滞在時間のほとんどなので、そこを先に決める

ナビ・サイドバー・検索は別の issue にする。

### 対象は `a` / `button` / `summary`。`[tabindex]` は含めない

ブログは `a, button, input, summary, [tabindex]` を 1 つの輪郭で扱っているが、

- `input` は本文の中にはタスクリストの checkbox（`markdown-it-task-lists` の既定で `disabled`）しか無く、フォーカスできない
- `[tabindex]` を入れると、スキップリンクの `focusOnTargetAnchor` が見出しに一時的に付ける `tabindex="-1"` に当たる。VitePress は `.vp-doc h1–h6 { outline: none }` で意図してそこの輪郭を消しているので、その判断を裏返さない
- `summary` は本文に 1 か所だけだが、ブログが同じ輪郭で扱っているのでそろえた

### 詳細度

- `.vp-doc a:focus-visible`（0,2,1）は `base.css` の `button:focus-visible`（0,1,1）に勝つ。`button:focus:not(:focus-visible) { outline: none !important }` は `:focus-visible` でないときだけ当たるので衝突しない
- スキップリンクは `.visually-hidden`（`position`、0,1,0）と `VPSkipLink.vue` の scoped style（色・影、`.VPSkipLink[data-v-…]` で 0,2,0）が見た目を持つので、`style.css` の他の規則と同じく `#app` を前置して 1,1,0 にした
- `:focus` で `clip` を外す scoped の規則（`.VPSkipLink[data-v-…]:focus`、0,3,0）は生きている。こちら側は `clip` / `width` / `height` を触っていない

### 位置（`top: 8px; left: 8px`）は変えない

ブログは「画面の角に貼り付けない（輪郭が画面の外に落ちて 2 辺が切れる）」としているが、VitePress は既定で縁から 8px（1280px 以上は 14px / 16px）空いているので、`outline-offset: 2px` の輪郭は画面の内側（縁から 6px）に収まる。`z-index: 999` と `border-radius: 8px` もそのまま。

### 共有ボタンの `:focus-visible` は触らない

本文の中の共有ボタン（`PageTitle.vue` の `.share-btn`）は `:focus-visible` に hover と同じ塗りを持つ。輪郭が足されるので所在は輪郭が名乗るようになるが、塗りも一緒に動く形は残る。ブログの「反応（hover）と所在（focus）は別の役」からは塗りを外すのが筋だが、外した見た目はブラウザで見ないと決められないのでこの PR では触らない。

## 確認したこと

- `npm run lint`（prettier + eslint）— 差分なし
- `npm run build` — 成功
- `docs/assets/*.css` に規則が焼かれていること
  - `.vp-doc a:focus-visible,.vp-doc button:focus-visible,.vp-doc summary:focus-visible,#app .VPSkipLink:focus-visible{outline:2px solid var(--vp-c-brand-3);outline-offset:2px}`
  - `.dark .vp-doc a:focus-visible,…{outline-color:var(--vp-c-text-1)}`
  - `#app .VPSkipLink{position:fixed;color:#fff;background-color:var(--vp-c-brand-3);box-shadow:none}`
  - `.dark #app .VPSkipLink{color:var(--vp-c-bg);background-color:var(--vp-c-brand-1)}`
- ビルド後の CSS の `outline` 宣言を全部並べて、本文の `a` / `button` / `summary` の `:focus-visible` に勝つ規則が他に無いことを確認
- `.VPSkipLink[data-v-701500f0]:focus{height:auto;width:auto;clip:auto;clip-path:none}` が残っていること
- 生成した 66 ページすべてに「本文へスキップ」が出ていること（`grep -rl` で 66 / 66）
- スキップリンクが `#app` の内側にあること、`position: fixed` の基準になるような `transform` / `filter` / `backdrop-filter` を持つ祖先が無いこと（磨りガラスの `backdrop-filter` は兄弟の `.VPNavBar` に付いている）

## 確認していないこと

- **`position: fixed` にしたことで、ページの途中で Tab を押しても先頭へ飛ばなくなることをブラウザで確かめていない**（手元にブラウザが無い）。カスケードと詳細度は生成 CSS を読んで確認したが、実際の振る舞いは目視が要る
- フォーカスリングの見え方（本文のリンク・コードブロックのコピーボタン・`::: code-group` のタブで輪郭が器の縁に切られないか）も目視していない
- スキップリンクの帯の見え方（ネイビーの板・白文字・角丸 8px）も目視していない
