### PR TITLE
注記の本文を本文と同じ大きさにする (#439)

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -368,6 +368,30 @@ h6 {
   margin-right: 4px;
 }
 
+/* 注記の本文を本文と同じ大きさ・同じ行間にする (#439)。技術ブログ (#2971 / #2864) と同じ。
+   注記の中も読み下す文章なので、添え・注記・小ラベルのための小さい段には置かない。
+   タイトルも同じ大きさで、太字だけで見出しと分かる（サイズを上げると注記が節の見出しの
+   ように強く見える）。行の高さは本文の段落（.vp-doc p）と同じ 28px。
+   中のインラインコードは --vp-custom-block-code-font-size ではなく
+   --vp-code-font-size（0.875em）が当たっている（.vp-doc :not(pre, h1〜h6) > code の方が
+   詳細度で勝つ）ので、相対値のまま本文と同じ 14px に付いてくる */
+:root {
+  --vp-custom-block-font-size: 16px;
+}
+.vp-doc .custom-block,
+.vp-doc .custom-block p {
+  line-height: 28px;
+}
+/* 表のセルは本文の表と同じ 14px / 24px のまま (#408 / #421)。VitePress は th だけ
+   .custom-block.custom-block th で注記の字送りを当て直すので font-size を戻し、
+   行の高さは .custom-block からの継承をここで止める（止めないと注記の中の表だけ
+   セルが 2px 高くなる） */
+.vp-doc .custom-block.custom-block th,
+.vp-doc .custom-block.custom-block td {
+  font-size: 14px;
+  line-height: 24px;
+}
+
 /* 注記の地の色を技術ブログの note にそろえる (#409)。名前は engine の語彙で交差するので
    意味で対応させる: tip（本サイトでは「推奨」）→ ブログの info（緑）、info（補足）→
    ブログの tip（灰青）、warning → warn、danger → alert。


### PR DESCRIPTION
Fixes #439

[#431](https://github.com/future-architect/arch-guidelines/issues/431) の候補2。

## 変更内容

注記（`::: tip` 等、**688 件**）の中を、本文と同じ 16px / 行間 28px にする。

```css
:root {
  --vp-custom-block-font-size: 16px;
}
.vp-doc .custom-block,
.vp-doc .custom-block p {
  line-height: 28px;
}
.vp-doc .custom-block.custom-block th,
.vp-doc .custom-block.custom-block td {
  font-size: 14px;
  line-height: 24px;
}
```

688 件のうち **680 件（98.8%）がタイトルを持つ**（tip 322 / info 269 / warning 97。info の 200 件は「参考」）。注記に書かれるのは本文の脇にある補足で、**推奨事項そのものは本文が持つ**。それでも本文と同じ大きさにするのは、注記の中も段落として読み下すもので、小さい段（添え・注記・小ラベル）に置く対象ではないから。技術ブログの note が本文と同じ段に乗っているのと同じ扱いにそろえる。

技術ブログ側では note の中の段落は `.article-entry p` の `text-body`（15.6px）・`leading-body`（1.75）で本文とまったく同じで、タイトルも同じ大きさの太字（サイズを上げると note が節の見出しのように強く見えるため、上げない）。12px の段は「添え・注記・件数・小ラベル」のもので読み下す文章には使わない（ブログ #2971 / #2864）。

## 判断した点（何を上げ、何を据え置いたか）

| 波及先 | 件数 | 判断 | 理由 |
| --- | --- | --- | --- |
| 段落・タイトル・箇条書き | 688 / 680 / 273 | **16px / 28px に上げる** | 読み下す文章。タイトルは太さ（600）だけで見出しと分かる |
| 中の引用 | 3 | **16px に上がる**（`.custom-block.custom-block blockquote > p` が同じ変数を引く） | 本文の引用も 16px なので、そろう |
| 中のインラインコード | 72 | **変数は触らない** | `--vp-custom-block-code-font-size`（13px）は **`.vp-doc` の中では効いていない**。`.vp-doc :not(pre, h1, …, h6) > code`（詳細度 0,1,2）が `.custom-block code`（0,1,1）に勝つため、実効値は `--vp-code-font-size: 0.875em`。相対値なので注記が 16px になれば自動で 14px（本文のインラインコードと同じ）になる。実測 12.25px → 14px |
| 中のコードブロック | 47 | **上がる（結果としてそろう）** | 同じく `0.875em` 相対。実測 12.25px → 14px で、**本文のコードブロックと同じ 14px / 23.8px** になった |
| 中の表 | 29 | **14px / 24px に据え置く** | #408 / #421 で決めた値。VitePress は `.custom-block.custom-block th`（0,2,1）で **th だけ**注記の字送りを当て直すので、変数だけ上げると **th 16px / td 14px** に割れる。さらに `line-height` は `.custom-block` から継承されてセルが 2px 高くなる（実測 43px → 45px）。両方をここで止めて本文の表と同じにした |
| `::: code-group` のタブ | 10 | 影響なし | `vp-code-group.css` が 14px を自前で持つ（実測 14px のまま） |
| `::: details` | 0 | — | 原稿に無い |
| `.vp-doc` の外の `.custom-block` | 0 | — | 実測でも 0 件（forDB / forAWS / forTechnicalWriting で確認） |

**箇条書きの `li` は触っていない**（#431 の候補1で別 PR が `li` に当てる）。ここでは `.custom-block` の `line-height` を継ぐだけなので、どちらの順にマージされても値は 28px でそろう。

## 確認したこと

`npm run lint`（prettier + eslint）と `npm run build` は通る。`docs/assets/style.*.css` に `--vp-custom-block-font-size: 16px` と 2 本の規則が焼かれていることを確認した。

実効値はビルド結果を headless Chrome（1440×900）で測った。

### `/documents/forDB/postgresql_guidelines`（注記 88 件）

| | 変更前 | 変更後 | 本文 |
| --- | --- | --- | --- |
| 注記の段落 | 14px / 24px | **16px / 28px** | 16px / 28px |
| 注記のタイトル | 14px / 24px / 600 | **16px / 28px / 600** | — |
| 注記の箇条書き | 14px / 24px | **16px / 28px** | — |
| 注記のインラインコード | 12.25px | **14px** | 14px |
| 注記のコードブロック | 12.25px | **14px / 23.8px** | 14px / 23.8px |
| 注記の表（th / td） | 14px / 24px | 14px / 24px | 14px / 24px |

### 縦に伸びる量

タイトル1行＋本文1段落の注記 43 件を実測した。**行数が変わらなければ、本文 n 行の注記で +4 × (n + 1) px** 伸びる。

| 本文の行数 | 変更前 | 変更後 | 差 |
| --- | --- | --- | --- |
| 1 行 | 90px | 98px | +8px |
| 2 行 | 114px | 126px | +12px |
| **3 行** | **138px** | **154px** | **+16px** |
| 4 行 | 162px | 182px | +20px |
| 5 行 | 186px | 210px | +24px |

字が大きくなるぶん折り返しが増える注記もあり、43 件のうち **5 件（11.6%）が本文の行数を1つ増やした**（2→3 行の 118 → 156px など、+36〜52px）。

ページ全体では注記の高さの合計が **16,531 → 19,137px（+2,606px、+15.8%）**、`.vp-doc` 全体が **122,064 → 124,670px（+2,606px、+2.1%）**。88 件の注記に対して平均 +29.6px/件。

### コントラスト比

文字色（`--vp-c-text-1`）と地の比は #409 で決めたまま動かない。WCAG の「大きい文字」の境目は 24px（太字は 18.66px）で、14px も 16px もその下なので**適用される閾値は 4.5 のまま変わらない**。タイトルは 16px の太字（600）だが 18.66px 未満なのでこちらも 4.5。実測値はいずれも大きく上回る。

| 地 | 明るい側 | 暗い側 |
| --- | --- | --- |
| tip | 9.82 | 9.54 |
| info | 9.60 | 9.54 |
| warning | 10.33 | 9.49 |
| danger | 8.55 | 9.55 |

中のインラインコードの地（一段濃い面）でも 7.02〜9.69。

### 見たページ

注記が密なページで、段落・タイトル・箇条書き・表・引用・コードブロック・`code-group` がそろっていることを確認した。

- `/documents/forDB/postgresql_guidelines`（注記 88 件、表・箇条書き）
- `/documents/forTechnicalWriting/technical_writing_guidelines`（59 件、引用を含む注記）
- `/documents/forAWS/aws_guidelines`（29 件、表を含む注記）
- `/documents/forTerraform/terraform_guidelines`（31 件、`::: code-group` と表）

