### PR TITLE
箇条書きのマーカーと行間を技術ブログの決まりにそろえる

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -368,6 +368,52 @@ h6 {
   margin-right: 4px;
 }
 
+/* 箇条書きのマーカーは「本文に添える属性」なので、文字より一段薄い段に乗せて
+   記号を主張させない (#2540)。専用の灰色は作らず VitePress のトークンを借りる。
+   中黒と連番で色を分けないのも同じ理由で、マーカーの扱いを一つに保つ */
+.vp-doc li::marker {
+  color: var(--vp-c-text-2);
+}
+
+/* 箇条書きも読み下す文章なので、行間は段落と同じ 1.75 (#2864)。VitePress 既定は
+   body の 24px（16px の文字で 1.5）を継ぐため、同じ本文の中で段落と項目の行間が
+   違っていた。単位なしで持つのは、注記や脚注のように親の字が小さい場所でも比が
+   保たれるため（px で当てると小さい字のところだけ開き気味になる）。
+   項目の間の 8px は落とす——1.75 の行間そのものが項目の区切りを作る */
+.vp-doc li {
+  line-height: 1.75;
+}
+.vp-doc li + li {
+  margin-top: 0;
+}
+
+/* 緩い箇条書き（項目の間に空行を置く形）の項目の空きは、本文では li > p の
+   margin 16px が持つので li + li を落としても残る。注記の中だけは
+   .custom-block p:first-child の margin: 0 がそれを消していて、8px の空きが
+   li + li だけで作られていた。空きを段落の側へ移して、見た目を保つ */
+.vp-doc .custom-block li > p:first-child {
+  margin: 8px 0;
+}
+
+/* マーカーと本文の間隔は li 側の padding で作る (#2500)。ul / ol の padding を
+   広げても、マーカーと本文が一緒に右へ動くだけで両者の間隔は変わらない。
+   中黒は「1.」より字が細く、同じ間隔でも広く見えるので詰める (#2531)。
+   タスクリストはマーカーを消して checkbox を置いているので外す（付けると
+   checkbox ごと右へずれる） */
+.vp-doc li:not(.task-list-item) {
+  padding-left: 0.4em;
+}
+.vp-doc ul > li:not(.task-list-item) {
+  padding-left: 0.15em;
+}
+
+/* 入れ子は1段ごとに字下げが積み上がる。2段目以降を詰めて、深い入れ子でも
+   モバイルの本文幅を残す (#2531)。1段目の 20px は本文との段差として保つ */
+.vp-doc li > ul,
+.vp-doc li > ol {
+  padding-left: 1rem;
+}
+
 /* 注記の地の色を技術ブログの note にそろえる (#409)。名前は engine の語彙で交差するので
    意味で対応させる: tip（本サイトでは「推奨」）→ ブログの info（緑）、info（補足）→
    ブログの tip（灰青）、warning → warn、danger → alert。


### PR DESCRIPTION
Fixes #442（#431 の候補1）

## 変更内容

`.vitepress/theme/style.css` にタスクリストの塊の直後へ7つの規則を足した。

| | 前 | 後 |
| --- | --- | --- |
| マーカーの色 | `#3c3c43`（本文と同じ） | `#67676c`（`--vp-c-text-2`） |
| 本文の `li` の行間 | 24px（16px で 1.5） | 28px（1.75。段落と同じ） |
| 1行の項目の送り | 32px（24 ＋ `li + li` の 8px） | 28px |
| 注記の中の `li`（14px） | 24px（比 1.71） | 24.5px（1.75） |
| 脚注の `li`（16px） | 24px（1.5）・`padding-left` 0 | 28px（1.75）・6.4px |
| マーカーと本文の間隔 | UA 既定（`li` の padding 0） | 中黒 0.15em / 連番 0.4em |
| 入れ子の字下げ | 全段 20px | 1段 20px、2段目以降 16px |

技術ブログ側の根拠は #2540（マーカーは全段 ●、色は一段薄い段。専用の灰色を作らない）/ #2864（`p` と `li` は同じ `leading-body` 1.75。項目の間に追加の空きは持たない）/ #2500・#2531（間隔は `li` 側の padding。中黒は字が細いぶん詰める。入れ子は2段目から 16px）。

## 判断した点

**行間は px ではなく単位なし（1.75）で持つ。** 技術ブログが `leading-body` = 1.75 の単位なしで持っているのに合わせた。実利もある——注記（`.custom-block`）は今 14px なので `28px` を当てると比が 2.0 になり、読み下す文章の行間としては開きすぎる（単位なしなら 24.5px で今の 24px とほぼ同じ）。#431 の候補2で注記が 16px に上がれば、そのとき自動で 28px になる。脚注（16px、16件）も候補9で 14px に落とす案があり、同じ理由で追随する。16px の本文では `.vp-doc p { line-height: 28px }` と同値なので、段落との一致は px で書いても単位なしで書いても同じ。

**タスクリストは `padding-left` からだけ外す**（`:not(.task-list-item)`）。165件は `list-style: none` で checkbox を置いているので、padding を当てると checkbox ごと右へずれる。一方 `line-height` と `li + li` は外していない——チェックリストも読み下す行なので、本文と同じ段に乗せる。

**緩い箇条書きは見た目を変えない。** 本文では項目の空きを `li > p` の `margin: 16px` が持つので、`li + li` を落としても 16px 残る。注記の中だけは `.custom-block p:first-child { margin: 0 }` がそれを消していて、8px の空きが `li + li` だけで作られていた。そこで注記の中の `li > p:first-child` に `margin: 8px 0` を戻し、同じ 8px を保つ。

**規則の置き場所。** 未マージの #433 / #436 / #437 が 34行目・119〜175行目・169行目付近を触っているので、衝突しないようタスクリストの塊の直後（368行目の後）に置いた。

## 確認したこと

`npm run lint`（prettier + eslint）と `npm run build` が通る。生成 CSS（`docs/assets/style.DvUV59bU.css`）に7つの規則が焼かれていることと、いずれも VitePress 既定より後ろに来ていることを確認した（既定は約31,000バイト目、この PR の規則は約114,000バイト目）。`.vp-doc li + li { margin-top: 0 }` は既定と同じ詳細度なので、後ろに来ていることが効いている。`.vp-doc li > ul`（0,1,2）は既定の `.vp-doc ul`（0,1,1）に勝ち、タスクリストの `.vp-doc ul.contains-task-list`（0,2,1）と `.vp-doc li.task-list-item > ul.contains-task-list`（0,3,2）には負けるので、タスクリストの字下げは今のまま動かない。

原稿に出る量を数え直した（`docs/**/*.html` 66ページの `.vp-doc` の中）。`li` は **7,056 件**（`ul` 6,535 / `ol` 521）で、入れ子（2段目以降）が **2,646 件**、最大3段。タスクリスト 165件（`forPerformanceTest/appendix` 144 / `performance_test` 21）、脚注の `li` 16件（5ページ）、注記の中の `li` 926件、緩い箇条書き（`li > p`）61件（12ページ。うち注記の中は4リスト）。原稿側は `documents/*/*.md` 30ファイルで箇条書きの行 **6,634**（うち入れ子 2,640）で、#431 に書いた 6,249 は数え直した結果こちらになった。

見た目は幅 1280px のヘッドレス Chrome で、生成物に「元の CSS に戻す」スタイルを被せた版と並べて実測した。

- マーカーの色は `rgb(60, 60, 67)` → `rgb(103, 103, 108)`。本文の文字は `rgb(60, 60, 67)` のまま
- 1行の項目の送りは 32px → 28px。注記の中（14px）は 32px → 24.5px
- **タスクリストの checkbox の左端は前後で同一**（3つのリストで 336 / 353 / 360px）。text の左端も同一
- 3段の入れ子の本文の左端は 356 / 376 / 396px → 358.4 / 376.79 / 395.18px（1段の刻みが 20px → 18.4px）
- 緩い箇条書きの項目の空きは、本文が 16px のまま、注記の中も 8px のまま
- ページの高さは52ページ合計で **+0.77%**（ページごとに −2.09% 〜 +2.01%）。1行の項目は 4px 詰まるが、折り返した行は1行ごとに 4px 開くため。折り返す項目は 3,376 件（1行が 3,588 件）

ダークモードもマーカーの色を実測した。`.dark` を当てると `rgb(152, 152, 159)`（`#98989f`）になり、地の `#1b1b1f` の上で 5.99。`--vp-c-text-2` を引いているのでテーマに追随している。

タスクリストのページ・3段の入れ子のページ・注記の中の緩い箇条書きのページは、部品を切り出したスクリーンショットを前後で見比べた。

## 確認していないこと

- ダークモードは値を測っただけで、目で見比べてはいない
- 実機（iOS の Hiragino）での折り返し位置。手元のフォントは Noto Sans CJK だけなので、折り返す項目の件数は概算
- モバイル幅での見た目。入れ子の字下げを詰めたのはここに効く変更だが、幅 1280px でしか測っていない
