### PR TITLE
mermaid の図の文字を選択したときの文字色を fill でも指定する

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -254,12 +254,18 @@
    #403 のブランドのネイビー。::-moz-selection は単独のルールにする。セレクタ
    リストに 1 つでも解釈できないセレクタが混ざると、Chrome / Safari はルール
    ごと捨てる（技術ブログ #3058） */
+/* SVG の <text> の文字色は color ではなく fill が決めるので、fill も同じ値にする (#449)。
+   mermaid が図に焼き付けた fill:#333 が残ると、ネイビーの帯の上で 1.29 になって
+   文字の形が消える（シーケンス図の 26 枚が該当）。foreignObject の中の HTML ラベルは
+   color が効くので、こちらは fill を無視する */
 ::-moz-selection {
   color: #fff;
+  fill: #fff;
   background: var(--vp-c-brand-3);
 }
 ::selection {
   color: #fff;
+  fill: #fff;
   background: var(--vp-c-brand-3);
 }
 /* ネイビーのまま暗い地に置くと帯とページの地の差が 1.05 で見えなくなるため、
@@ -267,10 +273,12 @@
    （brand-navy と同じ色相 233° のまま彩度を半分に落とした帯） */
 .dark ::-moz-selection {
   color: var(--vp-c-bg);
+  fill: var(--vp-c-bg);
   background: #c2c7eb;
 }
 .dark ::selection {
   color: var(--vp-c-bg);
+  fill: var(--vp-c-bg);
   background: #c2c7eb;
 }
 


### PR DESCRIPTION
Fixes #449

## 変更

既にある4本の `::selection` に `fill` を足した。`.vitepress/theme/style.css` の4行追加＋コメント。

```css
::selection {
  color: #fff;
  fill: #fff;
  background: var(--vp-c-brand-3);
}
```

暗い側は `fill: var(--vp-c-bg)`。焼き付いた #333 は暗い側の帯（#c2c7eb）の上では 7.62 あって読めているが、明るい側と暗い側で選択の見え方の型を割らないためにそろえた。

## 判断した点

- **当てる範囲を SVG に絞らない。** `fill` は HTML の文字には効かないので、`.mermaid-svg` などへ限定する理由が無い。限定すると、将来ほかの inline SVG を本文に置いたときに同じ不具合が再発する
- **帯の色を図の中だけ明るくする案は採らない。** 「白い紙の上の図」として明るい帯＋暗い文字にすれば `fill` の対応に依らず読めるが、同じページの中で選択の見え方が2種類になる。`fill` が効く Chrome / Edge では帯の型を1つに保てる

## 確認したこと

Chrome 140（Windows、`--headless=new`）で `/documents/forIF/if_guidelines.html` のシーケンス図を実際に全選択してスクリーンショットを撮り、図の領域の画素を数えた。

| | 図の中の濃い画素（帯を除く） |
| --- | --- |
| 修正前 | 6,226 |
| 修正後 | **855**（残りは箱の枠・ライフライン・矢印で、これらは stroke なので選択の対象外） |

目でも確認した。修正前は文字が帯に沈み、修正後は白抜きで読める。`fill` を足す／足さないの最小のページでも比べて、`color` が効かないのは SVG の `<text>` だけだと確かめてある（HTML の行はどちらでも白）。

`npm run lint` / `npm run build` は通っている。生成 CSS に `::selection{color:#fff;fill:#fff;background:var(--vp-c-brand-3)}` が焼かれていることを確認。

## 確認していないこと

Firefox / Safari が `::selection` の `fill` を受けるか。受けない場合はその2つで現状のまま（帯だけネイビー）になる。宣言が捨てられるだけで他の指定には影響しない。

## 技術ブログ側

同じ不具合がある（`::selection` はネイビー、`source/_mermaid/` の SVG に `.messageText{fill:#333}`）。あちらにも起票する。
