### PR TITLE
コードブロックの行間を 1.4 にする

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -11,6 +11,10 @@
    リンクの中のコードだけはリンクの色のまま */
 :root {
   --vp-code-color: var(--vp-c-text-1);
+  /* コードブロックの行間は「行として並ぶもの」の段 1.4 (#453)。技術ブログの
+     leading-row と同じで、読み下す文章の 1.75 とは目的が違う。行番号・強調行・
+     差分行も同じ変数を見るのでずれない */
+  --vp-code-line-height: 1.4;
 }
 .vp-doc .custom-block code {
   color: var(--vp-c-text-1);


### PR DESCRIPTION
Fixes #453

## 変更内容

`.vitepress/theme/style.css` の `--vp-code-color` を決めている `:root` ブロックに `--vp-code-line-height: 1.4` を足す。CSS 1行。文字の大きさ（`--vp-code-font-size: 0.875em`）は変えない。

```css
:root {
  --vp-code-color: var(--vp-c-text-1);
  --vp-code-line-height: 1.4;
}
```

## 判断した点

技術ブログ（future-architect.github.io）の決まり（#2864）で、行間の段は3つ（見出し 1.3 / 読み下す文章 1.75 / 行として並ぶもの 1.4）に絞っており、**コードブロックの1行は「行として並ぶもの」の 1.4**。読み下す文章の 1.75 とは目的が違い、開けるほど帯が縦に伸びて一度に見える行数が減る。#431 の候補10として棚卸し済みで「良し悪しが描いて見比べないと決まらない」として保留になっていたが、比較ページ（現状 1.7 と提案 1.4 を並べたもの）を見た利用者が 1.4 の採用を決めた。

## 実測

- `documents/forTerraform/terraform_guidelines.html` の modules ツリーの例（幅820px、15行のコードブロック）で 1行 23.8px → 19.6px
- 文字の大きさは 14px / 16px = 0.875 で、ブログの 13px / 15.6px = 0.833 と同じ向きにあるので変えない

## 確認したこと

ヘッドレス Chrome（Windows 側の Chrome を借りて実測）で、生成後の `docs/` を実際の CSS を読み込んだ状態で before(1.7) / after(1.4) を並べて確認した。

- **行番号の桁と本文の行のそろい**: `line-numbers-wrapper` は `--vp-code-line-height` を共有するのでずれない。実測でも1〜15行すべて一致
- **`::: code-group` のタブの中**: `web_frontend_guidelines.md` の HTML 記述例で確認。タブ切り替え・アクティブ下線とも崩れず、行間だけ縮む
- **注記（`:::` tip/info/warning）の中のコードブロック**: `technical_writing_guidelines.md` の「例: コードブロック」（NG/OK の2ブロック＋出力結果）で確認。custom-block の枠内でも行番号がそろったまま縮む
- **`diff` / 強調行**: 原稿中に `[!code diff]` 等のハイライト構文は使われていない（`grep` で0件）。使われても同じ CSS 変数を見るので仕組み上ずれない
- **長い行の折り返し**: `pre` は `overflow-x: auto`（`base.css`）で横スクロールする作りのままなので、行間を変えても折り返し方は変わらない
- `npm run lint`（prettier + eslint）／`npm run build` を実行し、生成 CSS（`docs/assets/*.css`）に `--vp-code-line-height: 1.4` が入っていることを確認
