### PR TITLE
コードブロックの行番号を出さない (#462)

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -242,7 +242,7 @@ export default defineConfig({
   outDir: "docs",
   ignoreDeadLinks: "localhostLinks",
   markdown: {
-    lineNumbers: true,
+    lineNumbers: false,
     config(md) {
       md.use(markdownItHeaderShift);
       md.use(markdownItTaskLists);


### PR DESCRIPTION
Fixes #462

## 変更内容

`.vitepress/config.mjs` の `markdown.lineNumbers` を `false` にして、コードブロックの行番号を出さないようにする。技術ブログ側（`_config.yml` の `highlight.line_number: false`）と同じ形になる。

## 判断した点

- **行番号が働いていない。** 行番号を参照している本文は0件（「N行目」と書いている4箇所は CSV の改行・protobuf の生成判定・リストの導入文の話で、コードブロックの溝を指したものではない）。行ハイライト（<code>```ts {3,5}</code>）も0件で、行番号と対で効く記法を使っていない
- **ブロックが短い。** mermaid を除く226ブロックの中央値は 7.5 行、40% が5行以下・26% が3行以下。中身も tf 44 / sh 39 / sql 37 / json 29 と貼って使う断片が中心で、行で指す読み方をしない
- **溝の中に線が1本増える。** VitePress の既定は 32px の溝と 1px の縦罫（`.line-numbers-wrapper` の `border-right`）。技術ブログ側はコードブロックに枠線を持たせず輪郭は地の差だけが作る方針なので、そこと逆を向いていた
- **失うものは無い。** コピーボタンは元から行番号を含まないので変化しない。将来どうしても行を指したい文書が出たら <code>```ts:line-numbers</code> でブロック単位に戻せる

## 確認したこと

- `npm run lint` / `npm run build` とも成功
- ビルド成果物の `docs/` を grep して、`line-numbers-mode` / `line-numbers-wrapper` を持つ HTML が0件になったことを確認（コードブロックを持つ HTML は24ファイル）
- mermaid の SVG キャッシュ未生成の警告は出ていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
